### PR TITLE
parser fixes and improvements

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -1,10 +1,10 @@
 import PikaParser as Parser
 
-const ϵ = Parser.epsilon
+const ε = Parser.epsilon
 
 # helper macro for lexemes
 macro le_str(x)
     return length(x) == 1 ? :(Parser.token($(only(x)))) : :(Parser.tokens($x))
 end
 
-opt(x) = Parser.first(x, ϵ)
+opt(x) = Parser.first(x, ε)

--- a/src/openqasm.jl
+++ b/src/openqasm.jl
@@ -7,18 +7,24 @@ import ..@le_str, ..opt
 rules = Dict(
     # terminal productions
     :eol => Parser.seq(le";", Parser.many(Parser.satisfy(isspace))),
-    :id => Parser.scan() do x
+    :id_main => Parser.scan() do x
         matched = match(r"^[a-z][a-zA-Z0-9_]*", x)
         isnothing(matched) && return 0
         length(matched.match)
     end,
-    :real => Parser.scan() do input
-        capture = match(r"^([-][0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([eE][-+]?[0-9]+)?", input)
+    :id => Parser.seq(:id_main, :wsopt), #TODO add not_followed_by or stricter lexing to prevent split ids
+    :real_nums => Parser.scan() do input
+        capture = match(r"^[-]?[0-9]+\.[0-9]*([eE][-+]?[0-9]+)?", input)
         isnothing(capture) ? 0 : length(capture.match)
     end,
-    :nninteger => Parser.some(Parser.satisfy(isdigit)),
-    :ws => Parser.some(Parser.satisfy(isspace)),
-    :wsopt => Parser.first(:ws, Parser.epsilon),
+    :real => Parser.seq(:real_nums, :wsopt),
+    :digit => Parser.satisfy(isdigit),
+    :digitdot => Parser.first(:digit, le"."),
+    :digitdote => Parser.first(:digitdot, le"e"),
+    :nninteger => Parser.seq(Parser.some(:digit), Parser.not_followed_by(:digitdote), :wsopt),
+    :ws_char => Parser.satisfy(isspace),
+    :ws => Parser.some(:ws_char),
+    :wsopt => Parser.many(:ws_char),
     # header
     :header => Parser.seq(
         le"OPENQASM",
@@ -31,38 +37,63 @@ rules = Dict(
         :regdeclkind => Parser.first(le"qreg", le"creg"),
         :ws,
         :id,
-        :regdecloptlength => opt(Parser.seq(le"[", :nninteger, le"]")),
+        Parser.first(
+            :regdecloptlength => Parser.seq(le"[", :nninteger, le"]"),
+            Parser.epsilon,
+        ),
         :eol,
     ),
+
     # math expressions
-    :expr => Parser.first(
-        :expr_neg => Parser.seq(le"-", :expr),
-        :expr_par => Parser.seq(le"(", :expr, le")"),
-        :expr_binaryop => Parser.first(
-            :expr_binaryop_plus => Parser.seq(:expr, :wsopt, :plus => le"+", :wsopt, :expr),
-            :expr_binaryop_minus => Parser.seq(:expr, :wsopt, :minus => le"-", :wsopt, :expr),
-            :expr_binaryop_divides => Parser.seq(:expr, :wsopt, :divides => le"/", :wsopt, :expr),
-            :expr_binaryop_times => Parser.seq(:expr, :wsopt, :times => le"*", :wsopt, :expr),
-            :expr_binaryop_power => Parser.seq(:expr, :wsopt, :power => le"^", :wsopt, :expr),
-        ),
-        :expr_unaryop => Parser.seq(
-            :unaryop => Parser.first(le"sin", le"cos", le"tan", le"exp", le"ln", le"sqrt"),
-            le"(",
-            :expr,
-            le")",
-        ),
-        :real,
-        :nninteger,
-        :pi => le"pi",
-        :id,
-    ),
+    Parser.precedence_cascade(n -> Symbol(:binop_prec_, n),
+        (same,next) -> :expr => Parser.first(
+                :additive_expr => Parser.seq(same, Parser.first(:plus => le"+", :minus => le"-"), :wsopt, next),
+                next,
+            ),
+        (same,next) ->
+            Parser.first(
+                :multiplicative_expr => Parser.seq(same, Parser.first(:times => le"*", :divides => le"/"), :wsopt, next),
+                next,
+            ),
+        (same,next) ->
+            Parser.first(
+                :pow_expr =>Parser.seq(next, :power => le"^", :wsopt, same),
+                next,
+            ),
+        (same,next) ->
+            Parser.first(
+                :unary_expr =>Parser.seq(
+                    :unary_fun_op => Parser.first(
+                        le"sin",
+                        le"cos",
+                        le"tan",
+                        le"exp",
+                        le"ln",
+                        le"sqrt",
+                        :unary_minus => Parser.seq(le"-", Parser.not_followed_by(:digitdot)), #spoiler: parsing of unary minuses is pure hell even in such a simple language
+                    ),
+                    :wsopt,
+                    next,
+                ),
+                next,
+            ),
+        (_, restart) ->
+            Parser.first(
+                :real,
+                :nninteger,
+                :pi => Parser.seq(le"pi", :wsopt),
+                :id, #needs wsopt; better wrap all atoms to something that whitespaces them
+                :paren_expr => Parser.seq(le"(", :wsopt, restart, le")", :wsopt),
+            ),
+    )...,
+
     # register reference as argument
     :argument => Parser.first(:argumentarray => Parser.seq(:id, le"[", :nninteger, le"]"), :id),
     # quantum operators
     :uop => Parser.first(
-        :uopu => Parser.seq(le"U", le"(", :exprlist, le")", :argument, :eol),
-        :uopcx => Parser.seq(le"CX", :ws, :argument, le",", :argument, :eol),
-        :uopcustom => Parser.seq(:id, opt(Parser.seq(le"(", opt(:exprlist), le")")), :anylist, :eol),
+        :uopu => Parser.seq(le"U", le"(", :wsopt, :exprlist, le")", :wsopt, :argument, :eol),
+        :uopcx => Parser.seq(le"CX", :ws, :argument, le",", :wsopt, :argument, :eol),
+        :uopcustom => Parser.seq(:id, opt(:uopcustom_in => Parser.seq(le"(", :wsopt, opt(:exprlist), le")", :wsopt)), :anylist, :eol),
     ),
     :qop => Parser.first(
         :uop,
@@ -79,13 +110,13 @@ rules = Dict(
     ),
     # list
     :anylist => Parser.first(:idlist, :mixedlist),
-    :idlist => Parser.first(:id, Parser.seq(:idlist, le",", :id)),
+    :idlist => Parser.first(:idcons => Parser.seq(:id, le",", :wsopt, :idlist), :id),
     :mixedlist => Parser.first(
         Parser.seq(:id, le"[", :nninteger, le"]"),
         Parser.seq(:mixedlist, le",", :id, opt(Parser.seq(le"[", :nninteger, le"]"))),
         Parser.seq(:idlist, le",", :id, le"[", :nninteger, le"]"),
     ),
-    :exprlist => Parser.first(:expr, Parser.seq(:exprlist, le",", :expr)),
+    :exprlist => Parser.first(:exprlist_in => Parser.seq(:expr, le",", :wsopt, :exprlist), :expr),
     # program
     :statement => Parser.first(
         :regdecl,
@@ -106,36 +137,34 @@ folds = Dict(
     :eol => (_, _) -> nothing,
     :ws => (_, _) -> nothing,
     :wsopt => (_, _) -> nothing,
-    :id => (v, s) -> Symbol(v),
+    :id_main => (v, s) -> Symbol(v),
+    :id => (_,(main,_)) -> main,
     :nninteger => (v, s) -> parse(Int64, v),
     :real => (v, s) -> parse(Float64, v),
     # header
     :version => (v, s) -> VersionNumber(v),
-    :header => (v, (_, _, version, _)) -> Expr(:format, :openqasm, version),
+    :header => (v, (_, _, version, _)) -> Expr(:call, :format, :openqasm, version),
     # register declaration (e.g. "qreg q[12];")
-    :regdecloptlength => (v, s) -> isempty(s) ? 1 : s[1].args[3],
+    :regdecloptlength => (v, (_, i, _)) -> i,
     :regdeclkind => (v, _) -> Symbol(v),
-    :regdecl => (v, (kind, _, name, length)) -> Expr(kind, name, length),
+    :regdecl => (v, (kind, _, name, length)) -> Expr(:call, kind, name, isnothing(length) ? 1 : length),
     # math expressions
-    :unaryop => (v, _) -> Symbol(v),
-    :binaryop => (v, _) -> Symbol(v),
     :pi => (_, _) -> pi,
-    :expr_neg => (v, (_, x)) -> :(-$x),
-    :expr_par => (v, (_, x, _)) -> x,
-    :expr_binaryop => (_, s) -> only(s),
     :plus => (_, _) -> :+,
     :minus => (_, _) -> :-,
     :times => (_, _) -> :*,
     :divides => (_, _) -> :/,
     :power => (_, _) -> :^,
-    map([:plus, :minus, :times, :divides, :power]) do rule
-        Symbol(:expr_binaryop_, rule) => (v, (a, _, op, _, b)) -> begin
-            Expr(:call, op, a, b)
-        end
-    end...,
-    :expr_unaryop => (v, (op, _, x, _)) -> Expr(:call, op, x),
-    :expr => (v, s) -> ((@info "expr" v only(s)); only(s)),
-    :exprlist => (v, s) -> error("unimplemented"),
+    :additive_expr => (v, (a, op, _, b)) -> Expr(:call, op, a, b),
+    :multiplicative_expr => (v, (a, op, _, b)) -> Expr(:call, op, a, b),
+    :pow_expr => (v, (a, op, _, b)) -> Expr(:call, op, a, b),
+    :unary_expr => (v, (op, _, a)) -> Expr(:call, op, a),
+    :unary_fun_op => (v, _) -> Symbol(v),
+    :unary_minus => (_, _) -> :-,
+    :base_exp => (_, (x,)) -> x,
+    :paren_expr => (v, (_, _, x, _, _)) -> x,
+    :expr => (v, (x,)) -> x,
+    :exprlist_in => (_, (e,_,_,el)) -> Expr(:tuple, e, el),
     # register references
     :argumentarray => (v, (id, _, index, _)) -> (id, index),
     :argument => (_, (x,)) -> if x isa Tuple
@@ -144,9 +173,11 @@ folds = Dict(
         Expr(:ref, x)
     end,
     # quantum operators
-    :uopu => (_, (_, _, params, _, x, _)) -> Expr(:call, Expr(:call, :u, params), x),
-    :uopcx => (_, (_, _, a, _, b, _)) -> Expr(:call, :cx, a, b),
-    :uopcustom => (_, (gate, _, params, _, targets, _)) -> Expr(:call, gate, targets...),
+    :uopu => (_, (_, _, _, params, _, _, arg, _)) -> Expr(:call, :uop, params, arg),
+    :uopcx => (_, (_, _, a, _, _, b, _)) -> Expr(:call, :cx, a, b),
+    :uopcustom => (_, (gate, params, targets, _)) -> Expr(:call, gate, params, targets),
+    :idcons => (_, (a, _, _, as)) -> Expr(:tuple, a, as),
+    :uopcustom_in => (_, (_,_,x,_,_)) -> x,
     :uop => (_, (e,)) -> e,
     :qopmeasure => (_, (_, src, _, dst, _)) -> Expr(:call, :measure, src, dst),
     :qopmeasure => (_, (_, target, _)) -> Expr(:call, :reset, target),
@@ -154,14 +185,20 @@ folds = Dict(
     # TODO gate declaration
     # program
     :program => (_, s) -> Expr(:block, s...),
-    :main => (_, (header, program)) -> Expr(:program, header, program),
+    :main => (_, (header, program)) -> Expr(:call, :program, header, program),
 )
 
 folder(match, p, subvals) =
     if haskey(folds, match.rule)
+        #@info "folding" match subvals # debug
         folds[match.rule](match.view, subvals)
     else
-        Parser.default_fold(match, p, subvals)
+        #@info "folding default fallthrough" match subvals # debug
+        if length(subvals)==1
+            subvals[1]
+        else
+            nothing
+        end
     end
 end
 

--- a/test/test_openqasm.jl
+++ b/test/test_openqasm.jl
@@ -43,7 +43,7 @@ end
 @testset "Header parsing" begin
     @testset "Valid header" begin
         input = "OPENQASM 2.0;"
-        expected = Expr(:format, :openqasm, v"2.0")
+        expected = Expr(:call, :format, :openqasm, v"2.0")
         state = PikaParser.parse(grammar, input)
         @test PikaParser.traverse_match(state, PikaParser.find_match_at!(state, :header, 1), fold = folder) == expected
     end
@@ -52,24 +52,24 @@ end
 @testset "Register declaration parsing" begin
     @testset "qreg declaration" begin
         input = "qreg q[2];"
-        expected = Expr(:qreg, :q, 2)
+        expected = Expr(:call, :qreg, :q, 2)
         state = PikaParser.parse(grammar, input)
         @test PikaParser.traverse_match(state, PikaParser.find_match_at!(state, :regdecl, 1), fold = folder) == expected
 
         input = "qreg q;"
-        expected = Expr(:qreg, :q, 1)
+        expected = Expr(:call, :qreg, :q, 1)
         state = PikaParser.parse(grammar, input)
         @test PikaParser.traverse_match(state, PikaParser.find_match_at!(state, :regdecl, 1), fold = folder) == expected
     end
 
     @testset "creg declaration" begin
         input = "creg c[3];"
-        expected = Expr(:creg, :c, 3)
+        expected = Expr(:call, :creg, :c, 3)
         state = PikaParser.parse(grammar, input)
         @test PikaParser.traverse_match(state, PikaParser.find_match_at!(state, :regdecl, 1), fold = folder) == expected
 
         input = "creg c;"
-        expected = Expr(:creg, :c, 1)
+        expected = Expr(:call, :creg, :c, 1)
         state = PikaParser.parse(grammar, input)
         @test PikaParser.traverse_match(state, PikaParser.find_match_at!(state, :regdecl, 1), fold = folder) == expected
     end
@@ -104,9 +104,16 @@ end
         @test PikaParser.traverse_match(state, PikaParser.find_match_at!(state, :expr, 1), fold = folder) == expected
     end
 
-    @testset "negation" begin
+    @testset "negated literal" begin
         input = "-3.14"
-        expected = Expr(:call, :-, 3.14)
+        expected = -3.14
+        state = PikaParser.parse(grammar, input)
+        @test PikaParser.traverse_match(state, PikaParser.find_match_at!(state, :expr, 1), fold = folder) == expected
+    end
+
+    @testset "unary negation operator" begin
+        input = "- 12.34 + -a + -(a)"
+        expected = :((-(12.34) + -a) + -a)
         state = PikaParser.parse(grammar, input)
         @test PikaParser.traverse_match(state, PikaParser.find_match_at!(state, :expr, 1), fold = folder) == expected
     end


### PR DESCRIPTION
some leftovers:

- uop folding works but probably doesn't match expectations
- would be nice to write actual strict scanners to have this very fast™, now the performance is smashed by parsing the whitespace&identifier&integer letters one by one (e.g., each real `123.345` also generates matches for 6 integer sub-suffixes, and consecutively 2 extra unnecessary suffix reals even with lexing phase on)

best!